### PR TITLE
Maximum calculation is moved to chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,6 @@ This application draws a 3-dimensional visualization of the social posts receive
 
 * Since the punch card chart is used for a specific data, axis information is harcoded. If needed this can be obtained by processing the data passed to the chart.
 
-* The maximum value for the posts count an a given day at a given time is also passed to the chart from the controller as the maximum calculation will be simpler in the controller than the chart. If needed all the values in the data can be accumulated in a single array and it's maximum value can be obtained.
+* ~~The maximum value for the posts count an a given day at a given time is also passed to the chart from the controller as the maximum calculation will be simpler in the controller than the chart. If needed all the values in the data can be accumulated in a single array and it's maximum value can be obtained.~~ This is now handled in the chart itself
 
 * The connection to the stream is not closed and is kept open as long as the app is kept opened. This can increase the memory consumed. If needed the connection can be closed and reopened and flushing the data in the mean time.

--- a/app/components/posts-timeline.js
+++ b/app/components/posts-timeline.js
@@ -118,17 +118,20 @@ export default Component.extend({
     this.updateChart();
   },
 
-  dataChanged: observer('data.@each.values', 'max', function () {
+  dataChanged: observer('data.@each.values', function () {
     this.updateChart();
   }),
 
   updateChart() {
     let svg = this.svg;
     let data = this.data;
-    let max = this.max;
     let radius = scaleSqrt();
     let transition = svg.transition().duration(500);
     let xScale = this.xScale;
+    let allvalues = data.reduce( (accumulator, currentvalue) => accumulator.concat(currentvalue.values), []);
+    allvalues.sort();
+    let max = allvalues[allvalues.length - 1];
+
 
     radius
       .range([0, 15])

--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -4,7 +4,6 @@ import { set } from '@ember/object';
 import { oneWay } from '@ember/object/computed';
 export default Controller.extend({
   streamer: service(),
-  max: 0,
   pinMedia: oneWay('pin.lastObject'),
   instaMedia: oneWay('instagram_media.lastObject'),
   youtubeVideo: oneWay('youtube_video.lastObject'),
@@ -59,7 +58,6 @@ export default Controller.extend({
     });
   },
   processChartData(json) {
-    let max = this.max;
     let data = this.data;
     let { timestamp } = json;
     let date = new Date(timestamp*1000);
@@ -67,11 +65,8 @@ export default Controller.extend({
     let hours = date.getHours();
     let dayObject = data[day];
     //Create new array as ember observer's @each can work one level deep only
-    let dayValues = Array.prototype.concat([],dayObject.values);
-    let value = ++dayValues[hours];
-    if(value > max) {
-      this.set('max', value);
-    }
+    let dayValues = dayObject.values.slice();
+    dayValues[hours]++;
     set(dayObject,'values', dayValues);
   }
 });

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -1,5 +1,5 @@
 <div class="container">
-  {{posts-timeline data=data max=max}}
+  {{posts-timeline data=data}}
   <br>
   <div class="media-container">
     <div class="row">

--- a/tests/integration/components/posts-timeline-test.js
+++ b/tests/integration/components/posts-timeline-test.js
@@ -216,9 +216,10 @@ module('Integration | Component | posts-timeline', function(hooks) {
     // Handle any actions with this.set('myAction', function(val) { ... });
 
     this.set('data', data);
-    await render(hbs`{{posts-timeline data=data max=4}}`);
+    await render(hbs`{{posts-timeline data=data}}`);
 
-    assert.equal(this.element.querySelectorAll('circle')[5].getAttribute('r'), '0', 'Radius is 0 when value is 0');
+    assert.ok((Number(this.element.querySelector('circle').getAttribute('r')) > 0), 'Radius is > 0 when value is > 0');
+    assert.equal(Number(this.element.querySelectorAll('circle')[5].getAttribute('r')), 0, 'Radius is 0 when value is 0');
 
     assert.equal(this.element.querySelector('circle').getAttribute('cx'), '9.533898305084733', 'X is calculated correctly for first element');
 


### PR DESCRIPTION
Maximum value for posts count an a given day at a given time is calculated at the chart itself.

Additionally the creation of new array for a day when a new post for the day arrives is changed from `Array.concat` to `Array.slice` for better performance.